### PR TITLE
Two bugfixes to parsing of GAMESS COSMO files.

### DIFF
--- a/profiles/to_sigma.py
+++ b/profiles/to_sigma.py
@@ -140,7 +140,7 @@ def get_seg_DataFrame(COSMO_contents):
         table_assign = ['n','atom','x / a.u.','y / a.u.','z / a.u.','charge / e','area / A^2','charge/area / e/A^2','potential']
     elif "GAMESS/COSab RESULTS" in COSMO_contents:
         # GAMESS: same unit (Bohr in GAMESS/COSab) as Dmol3 but format is different
-        sdata = re.search(r"\(X, Y, Z\)[\sa-zA-Z0-9\(\)\./\*]+\n([\s0-9\-\n.]+)(=+)", COSMO_contents, re.DOTALL).group(1).rstrip()
+        sdata = re.search(r"\(X, Y, Z\)[ a-zA-Z0-9\(\)\./\*]+\n([\s0-9\-\n.]+)(=+)", COSMO_contents, re.DOTALL).group(1).rstrip()
         table_assign = ['n','atom','x / a.u.','y / a.u.','z / a.u.','charge / e','area / A^2','charge/area / e/A^2','potential']
     # Annotate the columns appropriately with units(!)
     return pandas.read_csv(StringIO(sdata), names=table_assign, sep=r'\s+',engine= 'python')
@@ -156,7 +156,10 @@ def get_atom_DataFrame(COSMO_contents):
         table_assign = ['atomidentifier','x / A','y / A','z / A','?1','?2','?3','atom','?4']
     elif "GAMESS/COSab RESULTS" in COSMO_contents:
         # GAMESS: same unit (Angstrom in GAMESS) as Dmol3 but format is different
-        sdata = re.search(r"EQUILIBRIUM GEOMETRY[\sa-zA-Z0-9\(\)\./\*\n]+\-+\n(\s[\s\S]+)\n\n\n", COSMO_contents, re.DOTALL).group(1)
+        sdata = re.search(r"EQUILIBRIUM GEOMETRY[ a-zA-Z0-9\(\)\./\*\n]+\-+\n(\s[\s\S]+?)\n\n\n", COSMO_contents, re.DOTALL).group(1)
+        for x in keys(covalent_radius):
+            if len(x) == 2:
+                sdata = sdata.replace(x.upper(), x) #replaces CL with Cl etc, so that the rest of the script works.
         table_assign = ['atom','charge','x / A','y / A','z / A']
     # Annotate the columns appropriately with units(!)
     return pandas.read_csv(StringIO(sdata), names=table_assign, sep=r'\s+',engine = 'python')


### PR DESCRIPTION
This introduces two bugfixes for the parsing of GAMESS output files:

1. Previous regular expression only matched segments and atoms after the first minus sign appeared in the coordinate list. This is the case in the example file the script was tested against, but of course is not a general occurrence... (the molecule may be anywhere in the XYZ coordinates...).

2. GAMESS puts two letter atoms in all caps in the output file ("CL" for chlorine; chlorobenzene example below) which did not match with the covalent_radius dictionary. This is at least the case in the July 2024 release (most current).

```
      ***** EQUILIBRIUM GEOMETRY LOCATED *****
 COORDINATES OF ALL ATOMS ARE (ANGS)
   ATOM   CHARGE       X              Y              Z
 ------------------------------------------------------------
 CL         17.0  -2.6766712684   0.0000241120  -0.0001662742
 C           6.0  -0.9172854545   0.0000161276   0.0000595843
 C           6.0  -0.2471426954   1.2054189392  -0.0000210845
 C           6.0  -0.2471613191  -1.2053999849  -0.0000242800
 C           6.0   1.1371638312   1.1977117151   0.0000227093
 C           6.0   1.1371432182  -1.1977117948   0.0000195734
 C           6.0   1.8306573054  -0.0000048068   0.0000228211
 H           1.0  -0.7895846254   2.1308893153   0.0000039874
 H           1.0  -0.7896230760  -2.1308588008  -0.0000907079
 H           1.0   1.6689625901   2.1309092192  -0.0000188121
 H           1.0   1.6689353268  -2.1309132022  -0.0000797139
 H           1.0   2.9046737930  -0.0000320009   0.0000519258 
```

